### PR TITLE
Added camera pose for sensor to be in default view

### DIFF
--- a/models/dave_worlds/worlds/dave_graded_seabed.world
+++ b/models/dave_worlds/worlds/dave_graded_seabed.world
@@ -80,5 +80,12 @@
 
     <plugin name="sc_interface" filename="libuuv_sc_ros_interface_plugin.so"/>
 
+    <gui fullscreen='0'>
+      <camera name='user_camera'>
+        <pose frame=''>14.26 -12.53 0.054 -0.0 0.28 2.36</pose> 
+        <view_controller>orbit</view_controller>
+        <projection_type>perspective</projection_type>
+      </camera>
+    </gui>
   </world>
 </sdf>


### PR DESCRIPTION
This is to slightly improve the DVL Seabed Gradient Demo by adding a GUI camera pose to include the teledyne sensor in the initial view.

**To test**
Run either launch scripts to start gazebo and load a standalone DVL model containing a ocean world with a seabed and teledyne sensor.
```
roslaunch dave_demo_launch dave_dvl_gradient_demo_uuvsim.launch
roslaunch dave_demo_launch dave_dvl_gradient_demo_dsl.launch
```